### PR TITLE
Ported DI from Unity to AutoFac.

### DIFF
--- a/src/Etg.Yams/Etg.Yams.csproj
+++ b/src/Etg.Yams/Etg.Yams.csproj
@@ -31,40 +31,24 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    <Reference Include="Microsoft.Data.Edm, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Edm.5.7.0\lib\net40\Microsoft.Data.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    <Reference Include="Microsoft.Data.OData, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.OData.5.7.0\lib\net40\Microsoft.Data.OData.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Practices.Unity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Practices.Unity.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.Configuration.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Practices.Unity.RegistrationByConvention, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.RegistrationByConvention.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.1.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.7.0\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -89,8 +73,8 @@
     <Reference Include="System.Reactive.PlatformServices">
       <HintPath>..\..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
     </Reference>
-    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
+    <Reference Include="System.Spatial, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Spatial.5.7.0\lib\net40\System.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/src/Etg.Yams/YamsEntryPoint.cs
+++ b/src/Etg.Yams/YamsEntryPoint.cs
@@ -1,7 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Etg.Yams.Application;
 using Etg.Yams.Watcher;
-using Microsoft.Practices.Unity;
+using Autofac;
 
 namespace Etg.Yams
 {
@@ -12,24 +12,24 @@ namespace Etg.Yams
     {
         private readonly IDeploymentWatcher _deploymentWatcher;
         private readonly IApplicationPool _applicationPool;
-        private static IUnityContainer _unityContainer;
+        private static IContainer _container;
 
-        public YamsEntryPoint(YamsConfig config) : this(InitializeDefaultUnityContainer(config))
+        public YamsEntryPoint(YamsConfig config) : this(InitializeDefaultModules(config))
         {
         }
 
-        public YamsEntryPoint(IUnityContainer unityContainer)
+        public YamsEntryPoint(IContainer container)
         {
-            _deploymentWatcher = unityContainer.Resolve<IDeploymentWatcher>();
-            _applicationPool = unityContainer.Resolve<IApplicationPool>();
-            _unityContainer = unityContainer;
+            _deploymentWatcher = container.Resolve<IDeploymentWatcher>();
+            _applicationPool = container.Resolve<IApplicationPool>();
+            _container = container;
         }
 
-        public static IUnityContainer InitializeDefaultUnityContainer(YamsConfig config)
+        public static IContainer InitializeDefaultModules(YamsConfig config)
         {
-            _unityContainer = new UnityContainer();
-            DiModule.RegisterTypes(_unityContainer, config);
-            return _unityContainer;
+            var builder = new ContainerBuilder();
+            DiModule.RegisterTypes(builder, config);
+            return builder.Build();
         }
 
         public Task Start()

--- a/src/Etg.Yams/packages.config
+++ b/src/Etg.Yams/packages.config
@@ -1,18 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
+  <package id="Autofac" version="3.5.2" targetFramework="net461" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />
-  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
-  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net461" />
+  <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net461" />
+  <package id="Microsoft.Data.Services.Client" version="5.7.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Main" version="2.2.5" targetFramework="net45" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net45" />
-  <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
-  <package id="Unity" version="4.0.1" targetFramework="net45" />
+  <package id="System.Spatial" version="5.7.0" targetFramework="net461" />
   <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net45" />
 </packages>

--- a/test/Etg.Yams.Test/Etg.Yams.Test.csproj
+++ b/test/Etg.Yams.Test/Etg.Yams.Test.csproj
@@ -34,6 +34,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Etg.Yams.Fakes">
       <HintPath>FakesAssemblies\Etg.Yams.Fakes.dll</HintPath>
     </Reference>
@@ -41,32 +45,16 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    <Reference Include="Microsoft.Data.Edm, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Edm.5.7.0\lib\net40\Microsoft.Data.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    <Reference Include="Microsoft.Data.OData, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.OData.5.7.0\lib\net40\Microsoft.Data.OData.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Practices.Unity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Practices.Unity.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.Configuration.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Practices.Unity.RegistrationByConvention, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.RegistrationByConvention.dll</HintPath>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.7.0\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.QualityTools.Testing.Fakes, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
@@ -80,8 +68,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
+    <Reference Include="System.Spatial, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Spatial.5.7.0\lib\net40\System.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
@@ -134,6 +122,7 @@
     <Compile Include="Utils\TestUtils.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="Data\ApplicationConfigParser\AppConfig.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/test/Etg.Yams.Test/app.config
+++ b/test/Etg.Yams.Test/app.config
@@ -20,4 +20,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" /></startup></configuration>
+</configuration>

--- a/test/Etg.Yams.Test/packages.config
+++ b/test/Etg.Yams.Test/packages.config
@@ -1,13 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommonServiceLocator" version="1.3" targetFramework="net461" />
+  <package id="Autofac" version="3.5.2" targetFramework="net461" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net461" />
-  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net461" />
-  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net461" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net461" />
+  <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net461" />
+  <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net461" />
+  <package id="Microsoft.Data.Services.Client" version="5.7.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net461" />
-  <package id="System.Spatial" version="5.6.4" targetFramework="net461" />
-  <package id="Unity" version="4.0.1" targetFramework="net461" />
+  <package id="System.Spatial" version="5.7.0" targetFramework="net461" />
   <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net461" />
   <package id="xunit" version="2.1.0" targetFramework="net451" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />


### PR DESCRIPTION
In order to be able to move Yams projects to .xproj so it cam cross-compile to .Net Framework and .Net Core, the DI container previously used, Unity, has to be replaced with AutoFac since the previously wasn`t supported on .Net Core.

- Ported DI from Unity to AutoFac.
- Added Portability Analysis report for both Yams and its tests.