### PR TITLE
Downgrade dependency to .NET Framework 4.5.1

### DIFF
--- a/src/AzureBlobStorageDeploymentRepository/AzureBlobStorageDeploymentRepository.csproj
+++ b/src/AzureBlobStorageDeploymentRepository/AzureBlobStorageDeploymentRepository.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Etg.Yams.Azure.Storage</RootNamespace>
     <AssemblyName>Etg.Yams.AzureBlobStorageDeploymentRepository</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/AzureBlobStorageDeploymentRepository/app.config
+++ b/src/AzureBlobStorageDeploymentRepository/app.config
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1"/></startup></configuration>

--- a/src/AzureBlobStorageDeploymentRepository/packages.config
+++ b/src/AzureBlobStorageDeploymentRepository/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net461" />
+  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net451" />
 </packages>

--- a/src/AzureBlobStorageUpdateSession/AzureBlobStorageUpdateSession.csproj
+++ b/src/AzureBlobStorageUpdateSession/AzureBlobStorageUpdateSession.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Etg.Yams.Azure</RootNamespace>
     <AssemblyName>Etg.Yams.AzureBlobStorageUpdateSession</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/AzureBlobStorageUpdateSession/packages.config
+++ b/src/AzureBlobStorageUpdateSession/packages.config
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="3.5.2" targetFramework="net461" />
-  <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net461" />
-  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net461" />
-  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net461" />
-  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net461" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net461" />
-  <package id="Rx-Core" version="2.2.5" targetFramework="net461" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net461" />
-  <package id="Rx-Linq" version="2.2.5" targetFramework="net461" />
-  <package id="Rx-Main" version="2.2.5" targetFramework="net461" />
-  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net461" />
-  <package id="System.Spatial" version="5.6.4" targetFramework="net461" />
-  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net461" />
+  <package id="Autofac" version="3.5.2" targetFramework="net451" />
+  <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net451" />
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net451" />
+  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
+  <package id="Rx-Core" version="2.2.5" targetFramework="net451" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net451" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="net451" />
+  <package id="Rx-Main" version="2.2.5" targetFramework="net451" />
+  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net451" />
+  <package id="System.Spatial" version="5.6.4" targetFramework="net451" />
+  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net451" />
 </packages>

--- a/src/AzureUtils/AzureUtils.csproj
+++ b/src/AzureUtils/AzureUtils.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Etg.Yams.Azure</RootNamespace>
     <AssemblyName>Etg.Yams.AzureUtils</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/AzureUtils/app.config
+++ b/src/AzureUtils/app.config
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1"/></startup></configuration>

--- a/src/AzureUtils/packages.config
+++ b/src/AzureUtils/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net461" />
-  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net461" />
-  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net461" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net461" />
-  <package id="System.Spatial" version="5.6.4" targetFramework="net461" />
-  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net461" />
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net451" />
+  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
+  <package id="System.Spatial" version="5.6.4" targetFramework="net451" />
+  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net451" />
 </packages>

--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Etg.Yams</RootNamespace>
     <AssemblyName>Etg.Yams.Common</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Common/packages.config
+++ b/src/Common/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
 </packages>

--- a/src/Etg.Yams.Core/Etg.Yams.Core.csproj
+++ b/src/Etg.Yams.Core/Etg.Yams.Core.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Etg.Yams</RootNamespace>
     <AssemblyName>Etg.Yams.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Etg.Yams.Core/packages.config
+++ b/src/Etg.Yams.Core/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="3.5.2" targetFramework="net461" />
+  <package id="Autofac" version="3.5.2" targetFramework="net451" />
 </packages>

--- a/src/Etg.Yams/Etg.Yams.csproj
+++ b/src/Etg.Yams/Etg.Yams.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Etg.Yams</RootNamespace>
     <AssemblyName>Etg.Yams</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Etg.Yams/app.config
+++ b/src/Etg.Yams/app.config
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1"/></startup></configuration>

--- a/src/Etg.Yams/packages.config
+++ b/src/Etg.Yams/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="3.5.2" targetFramework="net461" />
-  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net461" />
-  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net461" />
-  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net461" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net461" />
-  <package id="System.Spatial" version="5.6.4" targetFramework="net461" />
-  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net461" />
+  <package id="Autofac" version="3.5.2" targetFramework="net451" />
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net451" />
+  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
+  <package id="System.Spatial" version="5.6.4" targetFramework="net451" />
+  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
Addresses #23
The host process is still allowed to use .NET 4.6.1 if it wants. Tests were not downgraded, and there is no need for it.
Samples (for Cloud Services at least, which is the one that suffers from targeting .NET 4.6) was not updated, as we'd need to do this once there are published nuget packages with the lowered dependency.
