### PR TITLE
Update Cloud Services sample to target .NET 4.5.1

### DIFF
--- a/Samples/Etg.Yams.Cloud/Etg.Yams.WorkerRole/Etg.Yams.WorkerRole.csproj
+++ b/Samples/Etg.Yams.Cloud/Etg.Yams.WorkerRole/Etg.Yams.WorkerRole.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Etg.Yams.WorkerRole</RootNamespace>
     <AssemblyName>Etg.Yams.WorkerRole</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
@@ -48,27 +48,27 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Etg.Yams, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Etg.Yams.1.0.13\lib\net461\Etg.Yams.dll</HintPath>
+      <HintPath>..\packages\Etg.Yams.1.0.14\lib\net451\Etg.Yams.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Etg.Yams.AzureBlobStorageDeploymentRepository, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Etg.Yams.1.0.13\lib\net461\Etg.Yams.AzureBlobStorageDeploymentRepository.dll</HintPath>
+      <HintPath>..\packages\Etg.Yams.1.0.14\lib\net451\Etg.Yams.AzureBlobStorageDeploymentRepository.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Etg.Yams.AzureBlobStorageUpdateSession, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Etg.Yams.1.0.13\lib\net461\Etg.Yams.AzureBlobStorageUpdateSession.dll</HintPath>
+      <HintPath>..\packages\Etg.Yams.1.0.14\lib\net451\Etg.Yams.AzureBlobStorageUpdateSession.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Etg.Yams.AzureUtils, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Etg.Yams.1.0.13\lib\net461\Etg.Yams.AzureUtils.dll</HintPath>
+      <HintPath>..\packages\Etg.Yams.1.0.14\lib\net451\Etg.Yams.AzureUtils.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Etg.Yams.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Etg.Yams.1.0.13\lib\net461\Etg.Yams.Common.dll</HintPath>
+      <HintPath>..\packages\Etg.Yams.1.0.14\lib\net451\Etg.Yams.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Etg.Yams.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Etg.Yams.1.0.13\lib\net461\Etg.Yams.Core.dll</HintPath>
+      <HintPath>..\packages\Etg.Yams.1.0.14\lib\net451\Etg.Yams.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Samples/Etg.Yams.Cloud/Etg.Yams.WorkerRole/app.config
+++ b/Samples/Etg.Yams.Cloud/Etg.Yams.WorkerRole/app.config
@@ -19,4 +19,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" /></startup></configuration>

--- a/Samples/Etg.Yams.Cloud/Etg.Yams.WorkerRole/packages.config
+++ b/Samples/Etg.Yams.Cloud/Etg.Yams.WorkerRole/packages.config
@@ -1,29 +1,29 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="3.5.2" targetFramework="net461" />
-  <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net461" />
-  <package id="Etg.Yams" version="1.0.13" targetFramework="net461" />
+  <package id="Autofac" version="3.5.2" targetFramework="net451" />
+  <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net451" />
+  <package id="Etg.Yams" version="1.0.14" targetFramework="net451" />
   <package id="Microsoft.AspNet.Cors" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.OwinSelfHost" version="5.2.3" targetFramework="net45" />
-  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net461" />
-  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net461" />
-  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net461" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net461" />
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net451" />
+  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net451" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Cors" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Security" version="3.0.1" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
   <package id="Owin" version="1.0" targetFramework="net45" />
-  <package id="Rx-Core" version="2.2.5" targetFramework="net461" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net461" />
-  <package id="Rx-Linq" version="2.2.5" targetFramework="net461" />
-  <package id="Rx-Main" version="2.2.5" targetFramework="net461" />
-  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net461" />
-  <package id="System.Spatial" version="5.6.4" targetFramework="net461" />
-  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net461" />
+  <package id="Rx-Core" version="2.2.5" targetFramework="net451" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net451" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="net451" />
+  <package id="Rx-Main" version="2.2.5" targetFramework="net451" />
+  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net451" />
+  <package id="System.Spatial" version="5.6.4" targetFramework="net451" />
+  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
Currently deploying with .NET 4.6 (without a startup task to install the framework) is not supported. It generates build warnings and actually runs in 4.5.1, but it could cause issues if somebody actually uses something from 4.6 that is not compatible with 4.5.1

Addresses remaining portion of #23