### PR TITLE
Update WindowsAzure.Storage to the latest version.

### DIFF
--- a/src/AzureBlobStorageDeploymentRepository/AzureBlobStorageDeploymentRepository.csproj
+++ b/src/AzureBlobStorageDeploymentRepository/AzureBlobStorageDeploymentRepository.csproj
@@ -35,21 +35,17 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.OData, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.OData.5.8.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.8.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WindowsAzure.Storage.6.2.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.Storage.8.4.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -62,9 +58,8 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Spatial, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Spatial.5.8.2\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/AzureBlobStorageDeploymentRepository/packages.config
+++ b/src/AzureBlobStorageDeploymentRepository/packages.config
@@ -1,15 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />
-  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net451" />
+  <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net451" />
+  <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
   <package id="Semver" version="2.0.4" targetFramework="net451" />
+  <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net451" />
+  <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net451" />
+  <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net451" />
+  <package id="System.Net.Requests" version="4.0.11" targetFramework="net451" />
   <package id="System.Runtime" version="4.1.0" targetFramework="net451" />
   <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net451" />
   <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net451" />
-  <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
+  <package id="System.Spatial" version="5.8.2" targetFramework="net451" />
   <package id="System.Text.RegularExpressions" version="4.1.0" targetFramework="net451" />
-  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net451" />
+  <package id="WindowsAzure.Storage" version="8.4.0" targetFramework="net451" />
 </packages>

--- a/src/AzureBlobStorageUpdateSession/AzureBlobStorageUpdateSession.csproj
+++ b/src/AzureBlobStorageUpdateSession/AzureBlobStorageUpdateSession.csproj
@@ -39,25 +39,21 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.OData, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.OData.5.8.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.8.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WindowsAzure.Storage.6.2.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.Storage.8.4.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -81,9 +77,8 @@
       <HintPath>..\..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Spatial, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Spatial.5.8.2\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/AzureBlobStorageUpdateSession/packages.config
+++ b/src/AzureBlobStorageUpdateSession/packages.config
@@ -3,15 +3,19 @@
   <package id="Autofac" version="3.5.2" targetFramework="net451" />
   <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net451" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net451" />
-  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net451" />
-  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net451" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net451" />
+  <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net451" />
+  <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net451" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net451" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="net451" />
   <package id="Rx-Main" version="2.2.5" targetFramework="net451" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net451" />
-  <package id="System.Spatial" version="5.6.4" targetFramework="net451" />
-  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net451" />
+  <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net451" />
+  <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net451" />
+  <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net451" />
+  <package id="System.Net.Requests" version="4.0.11" targetFramework="net451" />
+  <package id="System.Spatial" version="5.8.2" targetFramework="net451" />
+  <package id="WindowsAzure.Storage" version="8.4.0" targetFramework="net451" />
 </packages>

--- a/src/AzureUtils/AzureUtils.csproj
+++ b/src/AzureUtils/AzureUtils.csproj
@@ -35,21 +35,17 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.OData, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.OData.5.8.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.8.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WindowsAzure.Storage.6.2.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.Storage.8.4.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -57,9 +53,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Spatial, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Spatial.5.8.2\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/AzureUtils/Utils/BlobUtils.cs
+++ b/src/AzureUtils/Utils/BlobUtils.cs
@@ -85,7 +85,7 @@ namespace Etg.Yams.Azure.Utils
         public static Task UploadFile(string localPath, CloudBlobContainer blobContainer, string blobPath)
         {
             CloudBlockBlob blob = blobContainer.GetBlockBlobReference(blobPath);
-            return blob.UploadFromFileAsync(localPath, FileMode.Open);
+            return blob.UploadFromFileAsync(localPath);
         }
 
         public static Task UploadDirectory(string localDirPath, CloudBlobContainer blobContainer, string blobDirPath)

--- a/src/AzureUtils/packages.config
+++ b/src/AzureUtils/packages.config
@@ -1,10 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net451" />
-  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net451" />
-  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net451" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net451" />
+  <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net451" />
+  <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
-  <package id="System.Spatial" version="5.6.4" targetFramework="net451" />
-  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net451" />
+  <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net451" />
+  <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net451" />
+  <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net451" />
+  <package id="System.Net.Requests" version="4.0.11" targetFramework="net451" />
+  <package id="System.Spatial" version="5.8.2" targetFramework="net451" />
+  <package id="WindowsAzure.Storage" version="8.4.0" targetFramework="net451" />
 </packages>

--- a/src/Etg.Yams/Etg.Yams.csproj
+++ b/src/Etg.Yams/Etg.Yams.csproj
@@ -39,21 +39,17 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.OData, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.OData.5.8.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.8.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WindowsAzure.Storage.6.2.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.Storage.8.4.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -61,9 +57,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Spatial, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Spatial.5.8.2\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/Etg.Yams/packages.config
+++ b/src/Etg.Yams/packages.config
@@ -2,10 +2,14 @@
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net451" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net451" />
-  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net451" />
-  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net451" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net451" />
+  <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net451" />
+  <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
-  <package id="System.Spatial" version="5.6.4" targetFramework="net451" />
-  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net451" />
+  <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net451" />
+  <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net451" />
+  <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net451" />
+  <package id="System.Net.Requests" version="4.0.11" targetFramework="net451" />
+  <package id="System.Spatial" version="5.8.2" targetFramework="net451" />
+  <package id="WindowsAzure.Storage" version="8.4.0" targetFramework="net451" />
 </packages>

--- a/test/AzureBlobStorageDeploymentRepositoryTest/AzureBlobStorageDeploymentRepositoryTest.csproj
+++ b/test/AzureBlobStorageDeploymentRepositoryTest/AzureBlobStorageDeploymentRepositoryTest.csproj
@@ -40,21 +40,17 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.OData, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.OData.5.8.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.8.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WindowsAzure.Storage.6.2.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.Storage.8.4.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -66,9 +62,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Spatial, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Spatial.5.8.2\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>

--- a/test/AzureBlobStorageDeploymentRepositoryTest/packages.config
+++ b/test/AzureBlobStorageDeploymentRepositoryTest/packages.config
@@ -1,13 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />
-  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net461" />
+  <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net461" />
+  <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net461" />
   <package id="Semver" version="2.0.4" targetFramework="net461" />
-  <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net461" />
+  <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net461" />
+  <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net461" />
+  <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net461" />
+  <package id="System.Net.Requests" version="4.0.11" targetFramework="net461" />
+  <package id="System.Spatial" version="5.8.2" targetFramework="net461" />
+  <package id="WindowsAzure.Storage" version="8.4.0" targetFramework="net461" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/test/AzureBlobStorageUpdateSessionTest/AzureBlobStorageUpdateSessionTest.csproj
+++ b/test/AzureBlobStorageUpdateSessionTest/AzureBlobStorageUpdateSessionTest.csproj
@@ -50,17 +50,14 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.OData, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.OData.5.8.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.8.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll</HintPath>
@@ -69,9 +66,8 @@
     <Reference Include="Microsoft.QualityTools.Testing.Fakes, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WindowsAzure.Storage.6.2.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.Storage.8.4.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -83,9 +79,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Spatial, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Spatial.5.8.2\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>

--- a/test/AzureBlobStorageUpdateSessionTest/packages.config
+++ b/test/AzureBlobStorageUpdateSessionTest/packages.config
@@ -4,13 +4,17 @@
   <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net461" />
   <package id="Etg.SimpleStubs" version="2.3.1" targetFramework="net461" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />
-  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net461" />
+  <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net461" />
+  <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="Semver" version="2.0.4" targetFramework="net461" />
-  <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net45" />
+  <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net461" />
+  <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net461" />
+  <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net461" />
+  <package id="System.Net.Requests" version="4.0.11" targetFramework="net461" />
+  <package id="System.Spatial" version="5.8.2" targetFramework="net461" />
+  <package id="WindowsAzure.Storage" version="8.4.0" targetFramework="net461" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/test/AzureTestUtils/AzureTestUtils.csproj
+++ b/test/AzureTestUtils/AzureTestUtils.csproj
@@ -34,21 +34,17 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.OData, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.OData.5.8.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.8.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WindowsAzure.Storage.6.2.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.Storage.8.4.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -57,9 +53,8 @@
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Spatial, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Spatial.5.8.2\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/test/AzureTestUtils/packages.config
+++ b/test/AzureTestUtils/packages.config
@@ -1,10 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net451" />
-  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net451" />
-  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net451" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net451" />
+  <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net451" />
+  <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
-  <package id="System.Spatial" version="5.6.4" targetFramework="net451" />
-  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net451" />
+  <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net451" />
+  <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net451" />
+  <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net451" />
+  <package id="System.Net.Requests" version="4.0.11" targetFramework="net451" />
+  <package id="System.Spatial" version="5.8.2" targetFramework="net451" />
+  <package id="WindowsAzure.Storage" version="8.4.0" targetFramework="net451" />
 </packages>

--- a/test/AzureUtilsTest/AzureUtilsTest.csproj
+++ b/test/AzureUtilsTest/AzureUtilsTest.csproj
@@ -40,21 +40,17 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.OData, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.OData.5.8.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.8.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WindowsAzure.Storage.6.2.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.Storage.8.4.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -62,9 +58,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Spatial, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Spatial.5.8.2\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>

--- a/test/AzureUtilsTest/packages.config
+++ b/test/AzureUtilsTest/packages.config
@@ -1,12 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net461" />
-  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net461" />
-  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net461" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net461" />
+  <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net461" />
+  <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net461" />
+  <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net461" />
-  <package id="System.Spatial" version="5.6.4" targetFramework="net461" />
-  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net461" />
+  <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net461" />
+  <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net461" />
+  <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net461" />
+  <package id="System.Net.Requests" version="4.0.11" targetFramework="net461" />
+  <package id="System.Spatial" version="5.8.2" targetFramework="net461" />
+  <package id="WindowsAzure.Storage" version="8.4.0" targetFramework="net461" />
   <package id="xunit" version="2.1.0" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net461" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net461" />

--- a/test/FullIpcProcess/App.config
+++ b/test/FullIpcProcess/App.config
@@ -1,6 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.4.0.0" newVersion="8.4.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/test/FullIpcProcess/FullIpcProcess.csproj
+++ b/test/FullIpcProcess/FullIpcProcess.csproj
@@ -69,25 +69,21 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.OData, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.OData.5.8.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.8.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WindowsAzure.Storage.6.2.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.Storage.8.4.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -116,9 +112,8 @@
       <HintPath>..\..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Spatial, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Spatial.5.8.2\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/test/FullIpcProcess/packages.config
+++ b/test/FullIpcProcess/packages.config
@@ -5,9 +5,9 @@
   <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net452" />
   <package id="Etg.Yams" version="1.2.0-rc" targetFramework="net452" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net452" />
-  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net452" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net452" />
+  <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net452" />
+  <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net452" />
+  <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net452" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" />
@@ -15,10 +15,14 @@
   <package id="Rx-Main" version="2.2.5" targetFramework="net452" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net452" />
   <package id="Semver" version="2.0.4" targetFramework="net452" />
+  <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net452" />
+  <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net452" />
+  <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net452" />
+  <package id="System.Net.Requests" version="4.0.11" targetFramework="net452" />
   <package id="System.Runtime" version="4.1.0" targetFramework="net452" />
   <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net452" />
   <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net452" />
-  <package id="System.Spatial" version="5.6.4" targetFramework="net452" />
+  <package id="System.Spatial" version="5.8.2" targetFramework="net452" />
   <package id="System.Text.RegularExpressions" version="4.1.0" targetFramework="net452" />
-  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net452" />
+  <package id="WindowsAzure.Storage" version="8.4.0" targetFramework="net452" />
 </packages>

--- a/test/GracefullShutdownProcess/GracefullShutdownProcess.csproj
+++ b/test/GracefullShutdownProcess/GracefullShutdownProcess.csproj
@@ -70,25 +70,21 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.OData, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.OData.5.8.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.8.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WindowsAzure.Storage.6.2.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.Storage.8.4.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -117,9 +113,8 @@
       <HintPath>..\..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Spatial, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Spatial.5.8.2\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/test/GracefullShutdownProcess/app.config
+++ b/test/GracefullShutdownProcess/app.config
@@ -1,3 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.4.0.0" newVersion="8.4.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/test/GracefullShutdownProcess/packages.config
+++ b/test/GracefullShutdownProcess/packages.config
@@ -5,9 +5,9 @@
   <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net452" />
   <package id="Etg.Yams" version="1.2.0-rc" targetFramework="net452" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net452" />
-  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net452" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net452" />
+  <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net452" />
+  <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net452" />
+  <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net452" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" />
@@ -15,10 +15,14 @@
   <package id="Rx-Main" version="2.2.5" targetFramework="net452" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net452" />
   <package id="Semver" version="2.0.4" targetFramework="net452" />
+  <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net452" />
+  <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net452" />
+  <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net452" />
+  <package id="System.Net.Requests" version="4.0.11" targetFramework="net452" />
   <package id="System.Runtime" version="4.1.0" targetFramework="net452" />
   <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net452" />
   <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net452" />
-  <package id="System.Spatial" version="5.6.4" targetFramework="net452" />
+  <package id="System.Spatial" version="5.8.2" targetFramework="net452" />
   <package id="System.Text.RegularExpressions" version="4.1.0" targetFramework="net452" />
-  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net452" />
+  <package id="WindowsAzure.Storage" version="8.4.0" targetFramework="net452" />
 </packages>

--- a/test/HeartBeatProcess/App.config
+++ b/test/HeartBeatProcess/App.config
@@ -1,6 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.4.0.0" newVersion="8.4.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/test/HeartBeatProcess/HeartBeatProcess.csproj
+++ b/test/HeartBeatProcess/HeartBeatProcess.csproj
@@ -69,25 +69,21 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.OData, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.OData.5.8.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.8.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WindowsAzure.Storage.6.2.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.Storage.8.4.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -116,9 +112,8 @@
       <HintPath>..\..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Spatial, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Spatial.5.8.2\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/test/HeartBeatProcess/packages.config
+++ b/test/HeartBeatProcess/packages.config
@@ -5,9 +5,9 @@
   <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net452" />
   <package id="Etg.Yams" version="1.2.0-rc" targetFramework="net452" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net452" />
-  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net452" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net452" />
+  <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net452" />
+  <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net452" />
+  <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net452" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" />
@@ -15,10 +15,14 @@
   <package id="Rx-Main" version="2.2.5" targetFramework="net452" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net452" />
   <package id="Semver" version="2.0.4" targetFramework="net452" />
+  <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net452" />
+  <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net452" />
+  <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net452" />
+  <package id="System.Net.Requests" version="4.0.11" targetFramework="net452" />
   <package id="System.Runtime" version="4.1.0" targetFramework="net452" />
   <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net452" />
   <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net452" />
-  <package id="System.Spatial" version="5.6.4" targetFramework="net452" />
+  <package id="System.Spatial" version="5.8.2" targetFramework="net452" />
   <package id="System.Text.RegularExpressions" version="4.1.0" targetFramework="net452" />
-  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net452" />
+  <package id="WindowsAzure.Storage" version="8.4.0" targetFramework="net452" />
 </packages>

--- a/test/MonitorInitProcess/MonitorInitProcess.csproj
+++ b/test/MonitorInitProcess/MonitorInitProcess.csproj
@@ -70,25 +70,21 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.OData, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.OData.5.8.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.8.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WindowsAzure.Storage.6.2.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.Storage.8.4.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -117,9 +113,8 @@
       <HintPath>..\..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Spatial, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Spatial.5.8.2\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/test/MonitorInitProcess/app.config
+++ b/test/MonitorInitProcess/app.config
@@ -1,3 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.4.0.0" newVersion="8.4.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/test/MonitorInitProcess/packages.config
+++ b/test/MonitorInitProcess/packages.config
@@ -5,9 +5,9 @@
   <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net452" />
   <package id="Etg.Yams" version="1.2.0-rc" targetFramework="net452" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net452" />
-  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net452" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net452" />
+  <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net452" />
+  <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net452" />
+  <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net452" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" />
@@ -15,10 +15,14 @@
   <package id="Rx-Main" version="2.2.5" targetFramework="net452" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net452" />
   <package id="Semver" version="2.0.4" targetFramework="net452" />
+  <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net452" />
+  <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net452" />
+  <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net452" />
+  <package id="System.Net.Requests" version="4.0.11" targetFramework="net452" />
   <package id="System.Runtime" version="4.1.0" targetFramework="net452" />
   <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net452" />
   <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net452" />
-  <package id="System.Spatial" version="5.6.4" targetFramework="net452" />
+  <package id="System.Spatial" version="5.8.2" targetFramework="net452" />
   <package id="System.Text.RegularExpressions" version="4.1.0" targetFramework="net452" />
-  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net452" />
+  <package id="WindowsAzure.Storage" version="8.4.0" targetFramework="net452" />
 </packages>

--- a/test/Stubs/Stubs.csproj
+++ b/test/Stubs/Stubs.csproj
@@ -44,21 +44,17 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.OData, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.OData.5.8.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.8.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WindowsAzure.Storage.6.2.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.Storage.8.4.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -70,9 +66,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Spatial, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Spatial.5.8.2\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/test/Stubs/packages.config
+++ b/test/Stubs/packages.config
@@ -3,11 +3,15 @@
   <package id="CommandLineParser" version="1.9.71" targetFramework="net452" />
   <package id="Etg.SimpleStubs" version="2.3.1" targetFramework="net452" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net452" />
-  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net452" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net452" />
+  <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net452" />
+  <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net452" />
+  <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
   <package id="Semver" version="2.0.4" targetFramework="net452" />
-  <package id="System.Spatial" version="5.6.4" targetFramework="net452" />
-  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net452" />
+  <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net452" />
+  <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net452" />
+  <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net452" />
+  <package id="System.Net.Requests" version="4.0.11" targetFramework="net452" />
+  <package id="System.Spatial" version="5.8.2" targetFramework="net452" />
+  <package id="WindowsAzure.Storage" version="8.4.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
I want to use YAMS binaries in a FAKE build script for my application. Some of my dependences require newer WindowsAzure.Storage package (8.4.0) but YAMS uses 6.3.0 which is binary incompatibe. The only code change is `UploadFromFileAsync` method in `AzureUtils` which doesn't accept `FileMode` parameter in the latest version.