### PR TITLE
PropertiesDeploymentMatcher will ignore missing properties

### DIFF
--- a/src/Etg.Yams.Core/Deploy/PropertiesDeploymentMatcher.cs
+++ b/src/Etg.Yams.Core/Deploy/PropertiesDeploymentMatcher.cs
@@ -17,13 +17,12 @@ namespace Etg.Yams.Deploy
             foreach (var kvp in _matchProperties)
             {
                 string value;
-                if (!appDeploymentConfig.Properties.TryGetValue(kvp.Key, out value))
+                if (appDeploymentConfig.Properties.TryGetValue(kvp.Key, out value))
                 {
-                    return false;
-                }
-                if (value != kvp.Value)
-                {
-                    return false;
+                    if (value != kvp.Value)
+                    {
+                        return false;
+                    }
                 }
             }
             return true;

--- a/src/Etg.Yams/Etg.Yams.nuspec
+++ b/src/Etg.Yams/Etg.Yams.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Etg.Yams</id>
-    <version>1.2.1</version>
+    <version>1.3.0</version>
     <title>YAMS</title>
     <authors>Microsoft Studios (BigPark)</authors>
     <owners>Microsoft Studios (BigPark)</owners>

--- a/test/Etg.Yams.Core.Test/Data/EndToEndTest/DeploymentConfig.json
+++ b/test/Etg.Yams.Core.Test/Data/EndToEndTest/DeploymentConfig.json
@@ -26,7 +26,7 @@
       "TargetClusters": [ "clusterId2" ]
     },
     {
-      "Id": "test.app5",
+      "Id": "test.app5", // this app has no associated binaries
       "Version": "1.0.0",
       "TargetClusters": [ "clusterId1" ]
     }

--- a/test/Etg.Yams.Core.Test/Data/EndToEndTest/DeploymentConfigWithProperties.json
+++ b/test/Etg.Yams.Core.Test/Data/EndToEndTest/DeploymentConfigWithProperties.json
@@ -41,7 +41,7 @@
       "TargetClusters": [ "clusterId2" ]
     },
     {
-      "Id": "test.app5",
+      "Id": "test.app5", // this app has no associated binaries
       "Version": "1.0.0",
       "TargetClusters": [ "clusterId1" ]
     }


### PR DESCRIPTION
Only properties that are available on apps AND the cluster will be used for matching deployments. Properties that are not available on both the app and the cluster will no be matched on (they will still be
available to use as args in the appconfig.json).

This slightly changes the behaviour of how deployments are filtered based on cluster properties. Let me know if you have any concerns.