### PR TITLE
Cmdlet: Make most parameters optional and add better error reporting

### DIFF
--- a/src/Etg.Yams.Powershell/Etg.Yams.Powershell.nuspec
+++ b/src/Etg.Yams.Powershell/Etg.Yams.Powershell.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Etg.Yams.Powershell</id>
-    <version>1.0.3</version>
+    <version>1.1.1</version>
     <title>YAMS Powershell</title>
     <authors>Nehme Bilal</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
Most of the parameters of the cmdlet are now optional to provide the user with more control on what to execute. I also added better error reporting so users know what went wrong.

The default mode for uploading binaries has been set to `ConflictResolutionMode.DoNothingIfBinariesExist` and this setting has been exposed as an optional setting.