### PR TITLE
Do not redirect standard output

### DIFF
--- a/src/Etg.Yams.Core/Process/Process.cs
+++ b/src/Etg.Yams.Core/Process/Process.cs
@@ -61,9 +61,7 @@ namespace Etg.Yams.Process
 
                 if (!_showProcessWindow)
                 {
-                    _process.StartInfo.RedirectStandardOutput = true;
                     _process.StartInfo.UseShellExecute = false;
-                    _process.StartInfo.CreateNoWindow = true;
                 }
 
                 if (!_process.Start())


### PR DESCRIPTION
This fixes the issue described via gitter:

"any idea why my app behaves differently (locally) when 'ShowApplicationProcessWindow' is set to 'true' ?
any thoughts?"

My device message processor, which utilizes the microsoft EventProcessorHost, fails to consume messages if 'show process window' is false