### PR TITLE
Making SuperCluster a non-breaking change.

### DIFF
--- a/src/Etg.Yams.Core/YamsConfigBuilder.cs
+++ b/src/Etg.Yams.Core/YamsConfigBuilder.cs
@@ -12,7 +12,7 @@ namespace Etg.Yams
             _instanceUpdateDomain = instanceUpdateDomain;
             _instanceId = instanceId;
             _applicationInstallDirectory = applicationInstallDirectory;
-            _superClusterId = null;
+            _superClusterId = clusterId;
             _checkForUpdatesPeriodInSeconds = 10;
             _applicationRestartCount = 3;
             _processWaitForExitInSeconds = 5;
@@ -27,6 +27,11 @@ namespace Etg.Yams
 
         public YamsConfigBuilder SetSuperClusterId(string superClusterId)
         {
+            if (superClusterId == null)
+                throw new ArgumentNullException(
+                    nameof(superClusterId), 
+                    "SuperClusterId cannot be null. If you don't need to use SuperCluster feature than you don't have to set this setting - SuperClusterId will defaut to CluserId");
+
             _superClusterId = superClusterId;
             return this;
         }
@@ -100,7 +105,7 @@ namespace Etg.Yams
         public YamsConfig Build()
         {
             return new YamsConfig(
-                _superClusterId ?? _clusterId,
+                _superClusterId,
                 _clusterId,
                 _instanceUpdateDomain,
                 _instanceId,

--- a/src/Etg.Yams.Core/YamsConfigBuilder.cs
+++ b/src/Etg.Yams.Core/YamsConfigBuilder.cs
@@ -5,14 +5,14 @@ namespace Etg.Yams
 {
     public class YamsConfigBuilder
     {
-        public YamsConfigBuilder(string superClusterId, string clusterId, string instanceUpdateDomain, 
+        public YamsConfigBuilder(string clusterId, string instanceUpdateDomain, 
             string instanceId, string applicationInstallDirectory)
         {
-            this._superClusterId = superClusterId;
             _clusterId = clusterId;
             _instanceUpdateDomain = instanceUpdateDomain;
             _instanceId = instanceId;
             _applicationInstallDirectory = applicationInstallDirectory;
+            _superClusterId = null;
             _checkForUpdatesPeriodInSeconds = 10;
             _applicationRestartCount = 3;
             _processWaitForExitInSeconds = 5;
@@ -23,6 +23,12 @@ namespace Etg.Yams
             _ipcConnectTimeout = TimeSpan.FromSeconds(60);
             _appInitTimeout = TimeSpan.FromSeconds(60);
             _updateSessionTtl = TimeSpan.FromHours(1);
+        }
+
+        public YamsConfigBuilder SetSuperClusterId(string superClusterId)
+        {
+            _superClusterId = superClusterId;
+            return this;
         }
 
         public YamsConfigBuilder SetCheckForUpdatesPeriodInSeconds(int value)
@@ -94,7 +100,7 @@ namespace Etg.Yams
         public YamsConfig Build()
         {
             return new YamsConfig(
-                _superClusterId,
+                _superClusterId ?? _clusterId,
                 _clusterId,
                 _instanceUpdateDomain,
                 _instanceId,
@@ -112,11 +118,11 @@ namespace Etg.Yams
                 _clusterProperties);
         }
 
-        private readonly string _superClusterId;
         private readonly string _clusterId;
         private readonly string _instanceUpdateDomain;
         private readonly string _instanceId;
         private readonly string _applicationInstallDirectory;
+        private string _superClusterId;
         private int _checkForUpdatesPeriodInSeconds;
         private int _applicationRestartCount;
         private int _processWaitForExitInSeconds;

--- a/src/Etg.Yams.Host/Program.cs
+++ b/src/Etg.Yams.Host/Program.cs
@@ -20,12 +20,12 @@ namespace Etg.Yams.Host
 
             YamsConfig yamsConfig = new YamsConfigBuilder(
                     // mandatory configs
-                    superClusterId: superClusterId,
                     clusterId: clusterId,
                     instanceUpdateDomain: "0",
                     instanceId: "instance_0",
                     applicationInstallDirectory: Directory.GetCurrentDirectory())
                 // optional configs
+                .SetSuperClusterId(superClusterId)
                 .SetCheckForUpdatesPeriodInSeconds(5)
                 .SetApplicationRestartCount(int.MaxValue)
                 .Build();

--- a/src/Etg.Yams/Etg.Yams.nuspec
+++ b/src/Etg.Yams/Etg.Yams.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Etg.Yams</id>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <title>YAMS</title>
     <authors>Microsoft Studios (BigPark)</authors>
     <owners>Microsoft Studios (BigPark)</owners>

--- a/test/Etg.Yams.Core.Test/Application/ApplicationPoolTest.cs
+++ b/test/Etg.Yams.Core.Test/Application/ApplicationPoolTest.cs
@@ -41,7 +41,7 @@ namespace Etg.Yams.Test.Application
                 TestUtils.CopyExe(exeName, Path.Combine(ApplicationsRootPath, testAppRelPath));
             }
 
-            YamsConfig config = new YamsConfigBuilder("superClusterId", "clusterId", "1", "instanceId", "C:\\")
+            YamsConfig config = new YamsConfigBuilder("clusterId", "1", "instanceId", "C:\\")
                 .SetShowApplicationProcessWindow(false).SetApplicationRestartCount(0).Build();
             ApplicationFactory =
                 new ConfigurableApplicationFactory(new ApplicationConfigParser(

--- a/test/Etg.Yams.Core.Test/EndToEndTest.cs
+++ b/test/Etg.Yams.Core.Test/EndToEndTest.cs
@@ -112,7 +112,7 @@ namespace Etg.Yams.Test
         {
             const string ClusterId = "clusterId1";
             const string InstanceId = "instanceId";
-            var yamsConfig = new YamsConfigBuilder("superClusterId", ClusterId, "1", InstanceId,
+            var yamsConfig = new YamsConfigBuilder(ClusterId, "1", InstanceId,
                 _applicationsInstallPath).SetShowApplicationProcessWindow(false).Build();
 
             InitializeYamsService(yamsConfig);
@@ -175,7 +175,7 @@ namespace Etg.Yams.Test
         public async Task TestThatClusterPropertiesAreUsedToMatchDeployments()
         {
             UploadDeploymentConfig("DeploymentConfigWithProperties.json");
-            var yamsConfig = new YamsConfigBuilder("superClusterId", "clusterId1", "1", "instanceId",
+            var yamsConfig = new YamsConfigBuilder("clusterId1", "1", "instanceId",
                 _applicationsInstallPath).SetShowApplicationProcessWindow(false)
                 .AddClusterProperty("NodeType", "Test")
                 .AddClusterProperty("Region", "East").Build();
@@ -228,7 +228,7 @@ namespace Etg.Yams.Test
             await CopyAppBinariesToAppDeploymentDir("HeartBeatApp", "HeartBeatProcess", "1.0.0");
             UploadDeploymentConfig("DeploymentConfigHeartBeatApp.json");
 
-            var yamsConfig = new YamsConfigBuilder("superClusterId", "clusterId1", "1", "instanceId",
+            var yamsConfig = new YamsConfigBuilder("clusterId1", "1", "instanceId",
                     _applicationsInstallPath)
                 .SetAppHeartBeatTimeout(heartBeatTimeout)
                 .SetShowApplicationProcessWindow(false).Build();
@@ -250,7 +250,7 @@ namespace Etg.Yams.Test
             await CopyAppBinariesToAppDeploymentDir("MonitorInitApp", "MonitorInitProcess", "1.0.0");
             UploadDeploymentConfig("DeploymentConfigMonitorInitApp.json");
 
-            var yamsConfig = new YamsConfigBuilder("superClusterId", "clusterId1", "1", "instanceId",
+            var yamsConfig = new YamsConfigBuilder("clusterId1", "1", "instanceId",
                 _applicationsInstallPath).SetAppInitTimeout(TimeSpan.FromSeconds(10))
                 .SetShowApplicationProcessWindow(false).Build();
 
@@ -268,7 +268,7 @@ namespace Etg.Yams.Test
             await CopyAppBinariesToAppDeploymentDir("MonitorInitApp", "MonitorInitProcess", "1.0.0");
             UploadDeploymentConfig("DeploymentConfigMonitorInitApp.json");
 
-            var yamsConfig = new YamsConfigBuilder("superClusterId", "clusterId1", "1", "instanceId",
+            var yamsConfig = new YamsConfigBuilder("clusterId1", "1", "instanceId",
                     _applicationsInstallPath).SetAppInitTimeout(TimeSpan.FromSeconds(1))
                 .SetShowApplicationProcessWindow(false).Build();
 
@@ -297,7 +297,7 @@ namespace Etg.Yams.Test
             await CopyAppBinariesToAppDeploymentDir("GracefulShutdownApp", "GracefullShutdownProcess", "1.0.0");
             UploadDeploymentConfig("DeploymentConfigGracefulShutdownApp.json");
 
-            var yamsConfig = new YamsConfigBuilder("superClusterId", "clusterId1", "1", "instanceId",
+            var yamsConfig = new YamsConfigBuilder("clusterId1", "1", "instanceId",
                     _applicationsInstallPath).SetAppGracefulShutdownTimeout(gracefulShutdownTimeout)
                 .SetShowApplicationProcessWindow(false).Build();
 
@@ -318,7 +318,7 @@ namespace Etg.Yams.Test
             await CopyAppBinariesToAppDeploymentDir("FullIpcApp", "FullIpcProcess", "1.0.0");
             UploadDeploymentConfig("DeploymentConfigFullIpcApp.json");
 
-            var yamsConfig = new YamsConfigBuilder("superClusterId", "clusterId1", "1", "instanceId",
+            var yamsConfig = new YamsConfigBuilder("clusterId1", "1", "instanceId",
                     _applicationsInstallPath).SetShowApplicationProcessWindow(false).Build();
 
             InitializeYamsService(yamsConfig);

--- a/test/Etg.Yams.Core.Test/Process/GracefulShutdownProcessDecoratorTest.cs
+++ b/test/Etg.Yams.Core.Test/Process/GracefulShutdownProcessDecoratorTest.cs
@@ -10,7 +10,7 @@ namespace Etg.Yams.Test.Process
         [Fact]
         public async Task TestThatExitedEventIsNotFiredOnGracefulShutdown()
         {
-            var yamsConfig = new YamsConfigBuilder("superClusterId", "clusterId", "1", "instanceId", "C:\\Foo").Build();
+            var yamsConfig = new YamsConfigBuilder("clusterId", "1", "instanceId", "C:\\Foo").Build();
             var process = new StubIProcess().HasExited_Get(() => true);
             IIpcConnection connection = new StubIIpcConnection()
                 .SendMessage(message =>


### PR DESCRIPTION
Added `SetSuperClusterId` method to config builder.
ClusterId is passed SuperClusterId by default.