### PR TITLE
Add Get-DeploymentStatus cmdlet and some additional traces

### DIFF
--- a/src/Etg.Yams.Core/Download/ApplicationDownloader.cs
+++ b/src/Etg.Yams.Core/Download/ApplicationDownloader.cs
@@ -25,6 +25,7 @@ namespace Etg.Yams.Download
 
         public async Task DownloadApplication(AppIdentity appIdentity)
         {
+            Trace.TraceInformation($"Downloading application {appIdentity}");
             try
             {
                 string destPath = Path.Combine(_applicationRootPath,
@@ -32,6 +33,7 @@ namespace Etg.Yams.Download
                 await
                     _deploymentRepository.DownloadApplicationBinaries(appIdentity, destPath,
                         ConflictResolutionMode.OverwriteExistingBinaries);
+                Trace.TraceInformation($"Application {appIdentity} downloaded");
             }
             catch (BinariesNotFoundException)
             {

--- a/src/Etg.Yams.Core/Install/ApplicationInstaller.cs
+++ b/src/Etg.Yams.Core/Install/ApplicationInstaller.cs
@@ -26,24 +26,36 @@ namespace Etg.Yams.Install
 
         public async Task Install(AppInstallConfig appInstallConfig)
         {
+            AppIdentity appIdentity = appInstallConfig.AppIdentity;
+            Trace.TraceInformation($"Installing application {appIdentity}");
             IApplication application =
-                await _applicationFactory.CreateApplication(appInstallConfig, GetApplicationAbsolutePath(appInstallConfig.AppIdentity));
+                await _applicationFactory.CreateApplication(appInstallConfig, 
+                GetApplicationAbsolutePath(appInstallConfig.AppIdentity));
             try
             {
                 await _applicationPool.AddApplication(application);
-                
+                Trace.TraceInformation($"Application {appIdentity} installed");
             }
-            catch (Exception)
+            catch (Exception e)
             {
                 await DeleteAppBinaries(appInstallConfig.AppIdentity);
-                throw;
+                throw new Exception($"Failed to install application {appIdentity}", e);
             }
         }
 
         public async Task UnInstall(AppIdentity appIdentity)
         {
-            await _applicationPool.RemoveApplication(appIdentity);
-            await DeleteAppBinaries(appIdentity);
+            try
+            {
+                Trace.TraceInformation($"Uninstalling application {appIdentity}");
+                await _applicationPool.RemoveApplication(appIdentity);
+                await DeleteAppBinaries(appIdentity);
+                Trace.TraceInformation($"Application {appIdentity} uninstalled");
+            }
+            catch (Exception e)
+            {
+                throw new Exception($"Failed to uninstall application {appIdentity}", e);
+            }
         }
 
         public async Task<bool> Update(IEnumerable<AppIdentity> applicationsToRemove, IEnumerable<AppInstallConfig> applicationsToDeploy)

--- a/src/Etg.Yams.Core/Process/Process.cs
+++ b/src/Etg.Yams.Core/Process/Process.cs
@@ -1,11 +1,8 @@
 ﻿using Etg.Yams.Application;
 using Etg.Yams.Os;
-using Etg.Yams.Utils;
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Etg.Yams.Process
@@ -72,6 +69,7 @@ namespace Etg.Yams.Process
                     _process.StartInfo.EnvironmentVariables["PATH"] = system.GetPathEnvironmentVariable();
                 }
 
+                Trace.TraceInformation($"Starting Process with ExePath {_exePath}, arguments: {ExeArgs}");
                 if (!_process.Start())
                 {
                     await ReleaseResources();
@@ -80,6 +78,7 @@ namespace Etg.Yams.Process
                 }
 
                 _isRunning = true;
+                Trace.TraceInformation($"Process started: ExePath {_exePath}, arguments: {ExeArgs}");
             });
         }
 

--- a/src/Etg.Yams.Core/Storage/Config/DeploymentConfig.cs
+++ b/src/Etg.Yams.Core/Storage/Config/DeploymentConfig.cs
@@ -76,6 +76,13 @@ namespace Etg.Yams.Storage.Config
             return appIds;
         }
 
+        public IEnumerable<string> ListClusters()
+        {
+            var clusterIds = new HashSet<string>();
+            clusterIds.UnionWith(_apps.Values.SelectMany(config => config.TargetClusters));
+            return clusterIds;
+        }
+
         public IEnumerable<string> ListClusters(string appId)
         {
             var clusterIds = new HashSet<string>();

--- a/src/Etg.Yams.Core/Storage/Status/ClusterDeploymentStatus.cs
+++ b/src/Etg.Yams.Core/Storage/Status/ClusterDeploymentStatus.cs
@@ -1,10 +1,11 @@
 ﻿using Etg.Yams.Application;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Etg.Yams.Storage.Status
 {
-    public class ClusterDeploymentStatus
+    public class ClusterDeploymentStatus : IEnumerable<AppDeploymentStatus>
     {
         readonly Dictionary<string, InstanceDeploymentStatus> _instances = new Dictionary<string, InstanceDeploymentStatus>();
 
@@ -37,6 +38,16 @@ namespace Etg.Yams.Storage.Status
         public IEnumerable<AppDeploymentStatus> ListAll()
         {
             return _instances.Values.SelectMany(instance => instance.Applications);
+        }
+
+        public IEnumerator<AppDeploymentStatus> GetEnumerator()
+        {
+            return ListAll().GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
         }
     }
 }

--- a/src/Etg.Yams.Core/Storage/Status/DeploymentStatus.cs
+++ b/src/Etg.Yams.Core/Storage/Status/DeploymentStatus.cs
@@ -1,12 +1,15 @@
 ﻿using Etg.Yams.Application;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Etg.Yams.Storage.Status
 {
-    public class DeploymentStatus
+    public class DeploymentStatus : IEnumerable<AppDeploymentStatus>
     {
         private readonly Dictionary<string, ClusterDeploymentStatus> _clusters = new Dictionary<string, ClusterDeploymentStatus>();
+
+        public IEnumerable<string> ClustersIds => _clusters.Keys;
 
         public DeploymentStatus()
         {
@@ -58,6 +61,16 @@ namespace Etg.Yams.Storage.Status
         public IEnumerable<AppDeploymentStatus> ListAll()
         {
             return _clusters.Values.SelectMany(cluster => cluster.ListAll());
+        }
+
+        public IEnumerator<AppDeploymentStatus> GetEnumerator()
+        {
+            return ListAll().GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
         }
     }
 }

--- a/src/Etg.Yams.Powershell/Etg.Yams.Powershell.csproj
+++ b/src/Etg.Yams.Powershell/Etg.Yams.Powershell.csproj
@@ -53,6 +53,7 @@
   <ItemGroup>
     <Compile Include="ConnectDeploymentRepositoryCmdlet.cs" />
     <Compile Include="GetDeploymentConfigCmdlet.cs" />
+    <Compile Include="GetDeploymentStatusCmdlet.cs" />
     <Compile Include="InstallApplicationsCmdlet.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SetDeploymentConfigCmdlet.cs" />

--- a/src/Etg.Yams.Powershell/Etg.Yams.Powershell.nuspec
+++ b/src/Etg.Yams.Powershell/Etg.Yams.Powershell.nuspec
@@ -2,11 +2,12 @@
 <package >
   <metadata>
     <id>Etg.Yams.Powershell</id>
-    <version>1.1.3</version>
+    <version>1.2.1</version>
     <title>YAMS Powershell</title>
     <authors>Nehme Bilal</authors>
     <owners>Microsoft Studios (BigPark)</owners>
     <licenseUrl>https://opensource.org/licenses/MIT</licenseUrl>
+	<projectUrl>https://github.com/Microsoft/Yams</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Exposes several Powershell cmdlets that can be used to manage YAMS clusters.</description>
     <copyright>Copyright (c) Microsoft Corporation</copyright>

--- a/src/Etg.Yams.Powershell/GetDeploymentStatusCmdlet.cs
+++ b/src/Etg.Yams.Powershell/GetDeploymentStatusCmdlet.cs
@@ -19,9 +19,9 @@ namespace Etg.Yams.Powershell
         public string ClusterId { get; set; }
 
         [Parameter(Mandatory = false, 
-            HelpMessage = "Allow one to only show app that have been active within the last ActiveAgo seconds. " +
+            HelpMessage = "Allow one to only show app that have been active within the last ActiveSince seconds. " +
             "Default is 5 minutes")]
-        public int ActiveAgo { get; set; } = 300;
+        public int ActiveSince { get; set; } = int.MaxValue;
 
         protected override void ProcessRecord()
         {
@@ -65,7 +65,7 @@ namespace Etg.Yams.Powershell
         private DeploymentStatus GetClusterDeploymentStatus(BlobStorageDeploymentRepository deploymentRepository, 
             string clusterId)
         {
-            var apps = deploymentRepository.FetchClusterDeploymentStatus(clusterId, ttlSeconds: ActiveAgo).Result;
+            var apps = deploymentRepository.FetchClusterDeploymentStatus(clusterId, ttlSeconds: ActiveSince).Result;
             return new DeploymentStatus(apps);
         }
 
@@ -77,7 +77,7 @@ namespace Etg.Yams.Powershell
 
             foreach (string clusterId in clustersIds)
             {
-                var clusterStatus = deploymentRepository.FetchClusterDeploymentStatus(clusterId, ttlSeconds: ActiveAgo).Result;
+                var clusterStatus = deploymentRepository.FetchClusterDeploymentStatus(clusterId, ttlSeconds: ActiveSince).Result;
                 apps.AddRange(clusterStatus.ListAll());
             }
             return new DeploymentStatus(apps);

--- a/src/Etg.Yams.Powershell/GetDeploymentStatusCmdlet.cs
+++ b/src/Etg.Yams.Powershell/GetDeploymentStatusCmdlet.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Management.Automation;
+using Etg.Yams.Azure.Storage;
+using Etg.Yams.Storage;
+using Etg.Yams.Storage.Config;
+using Etg.Yams.Storage.Status;
+
+namespace Etg.Yams.Powershell
+{
+    [Cmdlet(VerbsCommon.Get, "DeploymentStatus")]
+    [OutputType(typeof(DeploymentConfig))]
+    public class GetDeploymentStatusCmdlet : Cmdlet
+    {
+        [Parameter(Mandatory = true, HelpMessage = "The connection string of the Yams storage")]
+        public string ConnectionString { get; set; }
+
+        [Parameter(Mandatory = false, HelpMessage = "The id of the cluster")]
+        public string ClusterId { get; set; }
+
+        [Parameter(Mandatory = false, 
+            HelpMessage = "Allow one to only show app that have been active within the last ActiveAgo seconds. " +
+            "Default is 5 minutes")]
+        public int ActiveAgo { get; set; } = 300;
+
+        protected override void ProcessRecord()
+        {
+            if (string.IsNullOrWhiteSpace(ConnectionString))
+            {
+                throw new ArgumentException(nameof(ConnectionString));
+            }
+
+            int activityId = 0;
+            var progressRecord = new ProgressRecord(activityId++, "Connect to blob storage",
+                "Connecting to blob storage");
+            WriteProgress(progressRecord);
+            var deploymentRepository = BlobStorageDeploymentRepository.Create(ConnectionString);
+            progressRecord.RecordType = ProgressRecordType.Completed;
+            WriteProgress(progressRecord);
+
+            progressRecord = new ProgressRecord(activityId++, "FetchDeploymentConfig", "Fetching DeploymentConfig from storage");
+            WriteProgress(progressRecord);
+            var deploymentConfig = deploymentRepository.FetchDeploymentConfig().Result;
+            progressRecord.RecordType = ProgressRecordType.Completed;
+            WriteProgress(progressRecord);
+
+            progressRecord = new ProgressRecord(activityId++, "FetchDeploymentStatus", $"Fetching DeploymentStatus");
+            WriteProgress(progressRecord);
+            var deploymentStatus = GetDeploymentStatus(deploymentRepository);
+            progressRecord.RecordType = ProgressRecordType.Completed;
+            WriteProgress(progressRecord);
+
+            WriteObject(deploymentStatus);
+        }
+
+        private DeploymentStatus GetDeploymentStatus(BlobStorageDeploymentRepository deploymentRepository)
+        {
+            if (string.IsNullOrWhiteSpace(ClusterId))
+            {
+                return GetAllClustersDeploymentStatus(deploymentRepository);
+            }
+            return GetClusterDeploymentStatus(deploymentRepository, ClusterId);
+        }
+
+        private DeploymentStatus GetClusterDeploymentStatus(BlobStorageDeploymentRepository deploymentRepository, 
+            string clusterId)
+        {
+            var apps = deploymentRepository.FetchClusterDeploymentStatus(clusterId, ttlSeconds: ActiveAgo).Result;
+            return new DeploymentStatus(apps);
+        }
+
+        private DeploymentStatus GetAllClustersDeploymentStatus(BlobStorageDeploymentRepository deploymentRepository)
+        {
+            var deploymentConfig = deploymentRepository.FetchDeploymentConfig().Result;
+            IEnumerable<string> clustersIds = deploymentConfig.ListClusters();
+            var apps = new List<AppDeploymentStatus>();
+
+            foreach (string clusterId in clustersIds)
+            {
+                var clusterStatus = deploymentRepository.FetchClusterDeploymentStatus(clusterId, ttlSeconds: ActiveAgo).Result;
+                apps.AddRange(clusterStatus.ListAll());
+            }
+            return new DeploymentStatus(apps);
+        }
+    }
+}

--- a/src/Etg.Yams.Powershell/InstallApplicationsCmdlet.cs
+++ b/src/Etg.Yams.Powershell/InstallApplicationsCmdlet.cs
@@ -12,6 +12,7 @@ using Newtonsoft.Json;
 
 namespace Etg.Yams.Powershell
 {
+
     [Cmdlet(VerbsLifecycle.Install, "Applications")]
     [OutputType(typeof(DeploymentConfig))]
     public class InstallApplicationsCmdlet : Cmdlet
@@ -36,7 +37,7 @@ namespace Etg.Yams.Powershell
 
         [Parameter(HelpMessage = "Waits until the deployment status has been updated, " +
                                  "which indicates that the corresponding apps have been started")]
-        public bool WaitForDeploymentsToComplete { get; set; }
+        public SwitchParameter WaitForDeploymentsToComplete { get; set; }
 
         [Parameter(HelpMessage = "Defines the behaviour when the binaries to upload already exist." +
                                  "The Default behaviour is to do nothing")]
@@ -44,10 +45,10 @@ namespace Etg.Yams.Powershell
 
         [Parameter(HelpMessage = "Indicates whether the DeploymentConfig.json should be uploaded" +
                                  "which will trigger deployment")]
-        public bool Deploy { get; set; } = true;
+        public SwitchParameter Deploy { get; set; } = true;
 
         [Parameter(HelpMessage = "Remove previously deployed version(s) of the app (Defaults to 'true')")]
-        public bool RemoveOldVersions { get; set; } = true;
+        public SwitchParameter RemoveOldVersions { get; set; } = true;
 
         [Parameter(HelpMessage = "The properties of the clusters; Entries order should correspond to entries in AppsIds. " +
             "Example: {\"app1Prop1key\":\"app1Prop1Value\", \"app1Prop2Key\":\"app1Prop2Value\"}, {\"app2Prop1key\":\"app2Prop1Value\"}.")]
@@ -221,6 +222,10 @@ namespace Etg.Yams.Powershell
                     waitForDeploymentsProgressRecord.RecordType = ProgressRecordType.Completed;
                     WriteProgress(waitForDeploymentsProgressRecord);
                 }
+            }
+            catch (ArgumentException argException)
+            {
+                ThrowTerminatingError(new ErrorRecord(argException, "0", ErrorCategory.InvalidArgument, null));
             }
             catch (Exception e)
             {


### PR DESCRIPTION
The `Get-DeploymentStatus` cmdlet is useful for displaying the current status of a given cluster or all clusters linked to a given storage account.

To get the status of all clusters, simply run
```powershell
Get-DeploymentStatus -ConnectionString "MyConnectionString"
```
Output sample:
```
AppIdentity  : [HealthMonitor (1.0.392)]
Id           : HealthMonitor
Version      : 1.0.392
ClusterId    : HealthMonitorCluster
InstanceId   : HealthMonitorWorkerRole_IN_0
UtcTimeStamp : 5/5/2018 5:13:41 PM

AppIdentity  : [NotificationService (1.0.397)]
Id           : NotificationService
Version      : 1.0.397
ClusterId    : FrontEnd
InstanceId   : WebApiWorkerRole_IN_0
UtcTimeStamp : 5/5/2018 5:13:42 PM

AppIdentity  : [NotificationService (1.0.397)]
Id           : NotificationService
Version      : 1.0.397
ClusterId    : FrontEnd
InstanceId   : WebApiWorkerRole_IN_1
UtcTimeStamp : 5/5/2018 5:13:44 PM

AppIdentity  : [NotificationService.Silo (1.0.397)]
Id           : NotificationService.Silo
Version      : 1.0.397
ClusterId    : Orleans
InstanceId   : SiloWorkerRole_IN_0
UtcTimeStamp : 5/5/2018 5:13:43 PM

AppIdentity  : [NotificationService.Silo (1.0.397)]
Id           : NotificationService.Silo
Version      : 1.0.397
ClusterId    : Orleans
InstanceId   : SiloWorkerRole_IN_1
UtcTimeStamp : 5/5/2018 5:13:43 PM
```

To only get the status of a specific cluster, run
```powershell
Get-DeploymentStatus -ConnectionString "MyConnectionString" -ClusterId "MyClusterId"
```

You can also use the `ActiveSince` parameter (which I struggled to find a good name for) to filter out nodes that have not been active recently (e.g. cluster has been scaled down). The command below will show the status of the clusters that have been active in the last minute.

```powershell
Get-DeploymentStatus -ConnectionString "MyConnectionString" -ClusterId "MyClusterId" -ActiveSince 60
```
